### PR TITLE
Updates treesitter query to address 'invalid node type' error

### DIFF
--- a/lua/neotest-deno/init.lua
+++ b/lua/neotest-deno/init.lua
@@ -95,13 +95,13 @@ function DenoNeotestAdapter.discover_positions(file_path)
 	function: (member_expression) @func_name (#match? @func_name "^Deno.test$")
 	arguments: [
 		(arguments ((string) @test.name . (arrow_function)))
-		(arguments . (function name: (identifier) @test.name))
+		(arguments . (function_expression name: (identifier) @test.name))
 		(arguments . (object(pair
 			key: (property_identifier) @key (#match? @key "^name$")
 			value: (string) @test.name
 		)))
 		(arguments ((string) @test.name . (object) . (arrow_function)))
-		(arguments (object) . (function name: (identifier) @test.name))
+		(arguments (object) . (function_expression name: (identifier) @test.name))
 	]
 ) @test.definition
 
@@ -110,7 +110,7 @@ function DenoNeotestAdapter.discover_positions(file_path)
 	function: (identifier) @func_name (#match? @func_name "^describe$")
 	arguments: [
 		(arguments ((string) @namespace.name . (arrow_function)))
-		(arguments ((string) @namespace.name . (function)))
+		(arguments ((string) @namespace.name . (function_expression)))
 	]
 ) @namespace.definition
 
@@ -134,7 +134,7 @@ function DenoNeotestAdapter.discover_positions(file_path)
 	function: (identifier) @func_name (#match? @func_name "^it$")
 	arguments: [
 		(arguments ((string) @test.name . (arrow_function)))
-		(arguments ((string) @test.name . (function)))
+		(arguments ((string) @test.name . (function_expression)))
 	]
 ) @test.definition
 	]]


### PR DESCRIPTION
The current (July 2025) version of `nvim-treesitter` was raising errors on multiple lines of the `query` in this module.  It appears that `function` is no longer a valid node type; using the [tree-sitter playgroud](https://tree-sitter.github.io/tree-sitter/7-playground.html).  I determined that `function_expression` is now used for this type of node.

Please note: I did not run the tests for this commit as there are no instructions on how to do so.